### PR TITLE
Harden data fetch: drop incomplete daily bars, FMP error handling, pagination & connection pooling

### DIFF
--- a/core/data_client.py
+++ b/core/data_client.py
@@ -14,6 +14,7 @@ import threading
 import time
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
+from zoneinfo import ZoneInfo
 
 import numpy as np
 import pandas as pd
@@ -102,6 +103,30 @@ def _period_to_days(period: str) -> int:
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+
+_US_EASTERN = ZoneInfo("America/New_York")
+
+
+def _drop_incomplete_daily_bar(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop today's bar when the regular session has not closed in US/Eastern."""
+    if df.empty:
+        return df
+
+    now_et = datetime.now(tz=_US_EASTERN)
+    if now_et.weekday() >= 5 or now_et.hour >= 16:
+        return df
+
+    idx = df.index
+    if idx.tz is not None:
+        latest_bar_date_et = idx[-1].tz_convert(_US_EASTERN).date()
+    else:
+        latest_bar_date_et = idx[-1].tz_localize("UTC").tz_convert(_US_EASTERN).date()
+
+    if latest_bar_date_et == now_et.date():
+        return df.iloc[:-1]
+    return df
+
+
 def _get_fmp_session() -> requests.Session:
     """Create a requests session with built-in retry logic."""
     session = requests.Session()
@@ -110,7 +135,15 @@ def _get_fmp_session() -> requests.Session:
         backoff_factor=2,
         status_forcelist=[429, 500, 502, 503, 504]
     )
-    session.mount("https://", HTTPAdapter(max_retries=retries))
+    pool_size = max(settings.HTTP_MAX_WORKERS, settings.MAX_WORKERS, 10)
+    session.mount(
+        "https://",
+        HTTPAdapter(
+            max_retries=retries,
+            pool_connections=pool_size,
+            pool_maxsize=pool_size,
+        ),
+    )
     return session
 
 _fmp_session = _get_fmp_session()
@@ -123,7 +156,15 @@ def _fmp_get(endpoint: str, params: Optional[dict] = None) -> Any:
 
     resp = _fmp_session.get(url, params=params, timeout=30)
     resp.raise_for_status()
-    return resp.json()
+    data = resp.json()
+
+    if isinstance(data, dict):
+        error_msg = data.get("Error Message") or data.get("error") or data.get("message")
+        if error_msg:
+            print(f"FMP API warning ({endpoint}): {error_msg}")
+            return []
+
+    return data
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -162,14 +203,16 @@ def fetch_ohlcv(
     )
 
     barset = client.get_stock_bars(request_params)
-    df = barset.df
+    frames = [barset.df]
 
     while barset.next_page_token is not None:
         request_params.page_token = barset.next_page_token
         next_barset = client.get_stock_bars(request_params)
         if not next_barset.df.empty:
-            df = pd.concat([df, next_barset.df])
+            frames.append(next_barset.df)
         barset.next_page_token = next_barset.next_page_token
+
+    df = pd.concat(frames) if frames else pd.DataFrame()
 
     if df.empty:
         empty = pd.DataFrame(columns=["Open", "High", "Low", "Close", "Volume"])
@@ -195,6 +238,8 @@ def fetch_ohlcv(
     # Strip timezone to match yfinance tz-naive output
     if df.index.tz is not None:
         df.index = df.index.tz_localize(None)
+
+    df = _drop_incomplete_daily_bar(df)
 
     df = df.astype(
         {
@@ -249,14 +294,16 @@ def fetch_bulk_close_prices(
                 adjustment=Adjustment.ALL,
             )
             barset = client.get_stock_bars(request_params)
-            df = barset.df
+            frames = [barset.df]
 
             while barset.next_page_token is not None:
                 request_params.page_token = barset.next_page_token
                 next_barset = client.get_stock_bars(request_params)
                 if not next_barset.df.empty:
-                    df = pd.concat([df, next_barset.df])
+                    frames.append(next_barset.df)
                 barset.next_page_token = next_barset.next_page_token
+
+            df = pd.concat(frames) if frames else pd.DataFrame()
 
             if df.empty:
                 print(f"  Batch {batch_num} returned empty data, skipping.")
@@ -267,6 +314,8 @@ def fetch_bulk_close_prices(
 
             if close_series.index.tz is not None:
                 close_series.index = close_series.index.tz_localize(None)
+
+            close_series = _drop_incomplete_daily_bar(close_series)
 
             all_frames.append(close_series)
             time.sleep(0.5)  # respect Alpaca rate limits


### PR DESCRIPTION
### Motivation
- Prevent incomplete intraday daily bars from distorting daily-volume-based CANSLIM metrics by ensuring only completed US regular-session days are used. 
- Avoid worker crashes when FMP returns JSON-style error payloads with HTTP 200 responses. 
- Prevent thread-level socket contention by matching the HTTP adapter connection pool to configured worker concurrency. 
- Eliminate repeated in-loop `pd.concat` calls that cause DataFrame fragmentation and performance warnings.

### Description
- Added `_drop_incomplete_daily_bar` which removes the current trading day’s bar when the US regular session (America/New_York) has not closed and applied it in `fetch_ohlcv` and `fetch_bulk_close_prices` for both single-symbol and bulk downloads. 
- Refactored Alpaca pagination in `fetch_ohlcv` and `fetch_bulk_close_prices` to collect page `DataFrame`s in a Python list and call `pd.concat` once at the end to avoid repeated reallocation. 
- Updated `_get_fmp_session` to configure `HTTPAdapter` with `pool_connections` and `pool_maxsize` set to `max(settings.HTTP_MAX_WORKERS, settings.MAX_WORKERS, 10)` to avoid socket-pool bottlenecks. 
- Hardened `_fmp_get` to inspect JSON responses for `"Error Message"`, `"error"`, or `"message"`, log a warning, and return an empty list so downstream code degrades gracefully instead of raising `AttributeError`.

### Testing
- Ran `python -m compileall core/data_client.py` and the module compiled successfully. 
- No unit tests were modified in this change; runtime behavior changes limited to data fetching logic and connection configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2dc42300c8330b6a48627137765b7)